### PR TITLE
Improved calibration config. Refactor create_first_guess.py

### DIFF
--- a/interactive_calibration/calibrations/atlascar2/atlascar2_calibration2.json
+++ b/interactive_calibration/calibrations/atlascar2/atlascar2_calibration2.json
@@ -1,0 +1,38 @@
+{
+    "sensors": {
+        "top_right_camera": {
+                "link": "top_right_camera_optical",
+                "parent_link": "base_link",
+                "child_link": "top_right_camera",
+                "topic_name": "/top_right_camera/image_color"
+        },
+            "top_left_camera": {
+                "link": "top_left_camera_optical",
+                "parent_link": "base_link",
+                "child_link": "top_left_camera",
+                "topic_name": "/top_left_camera/image_color"
+        },
+        "right_laser": {
+                "link": "right_laser",
+                "parent_link": "base_link",
+                "child_link": "right_laser",
+                "topic_name": "/right_laser/laserscan"
+        },
+            "left_laser": {
+                "link": "left_laser",
+                "parent_link": "base_link",
+                "child_link": "left_laser",
+                "topic_name": "/left_laser/laserscan"
+        }
+    },
+
+    "world_link": "base_link",
+
+    "calibration_pattern" : {
+        "pattern_type": "chessboard",
+        "border_size": 0.5,
+        "dimension": [9, 7],
+        "size": 0.019
+    }
+}
+

--- a/interactive_calibration/scripts/create_first_guess.py
+++ b/interactive_calibration/scripts/create_first_guess.py
@@ -1,124 +1,118 @@
 #!/usr/bin/env python
 
-# ------------------------
-#    IMPORT MODULES      #
-# ------------------------
+import sys
+import os.path
 import argparse
 
-from interactive_markers.interactive_marker_server import *
-from interactive_markers.menu_handler import MenuHandler
-from urdf_parser_py.urdf import URDF
-import rospkg
-# from AtlasCarCalibration.interactive_calibration.src.Sensor import *
 from colorama import Fore, Back, Style
 
-import interactive_calibration.sensor
+# ROS imports
+import rospkg
 
-# from interactive_calibration import D
-from graphviz import Digraph
-import json
+from interactive_markers.interactive_marker_server import *
+from interactive_markers.menu_handler              import MenuHandler
 
-# from interactive_calibration import Tra
+from urdf_parser_py.urdf import URDF
 
-# ------------------------
-#      BASE CLASSES      #
-# ------------------------
+# __self__ imports
+from interactive_calibration.utilities import CalibConfig, validateLinks
+from interactive_calibration.sensor    import Sensor
 
-# ------------------------
-#      GLOBAL VARS       #
-# ------------------------
+class InteractiveFirstGuess(object):
 
-server = None
-menu_handler = MenuHandler()
+    def __init__(self, args):
+        # command line arguments
+        self.args = args
+        # calibration config
+        self.config = None
+        # sensors
+        self.sensors = []
+        # robot URDF
+        self.urdf = None
+        # interactive markers server
+        self.server = None
+        self.menu   = None
 
+    def init(self):
+        # The parameter /robot_description must exist
+        if not rospy.has_param('/robot_description'):
+            rospy.logerr("The parameter does not '/robot_description' and it is required to continue")
+            sys.exit(1)
 
-# ------------------------
-#      FUNCTIONS         #
-# ------------------------
+        self.config = CalibConfig()
+        ok = self.config.loadJSON(self.args['calibration_file'])
+        # Exit if it fails to open a valid calibration file
+        if not ok: sys.exit(1)
 
-def menuFeedback(feedback):
-    # print('called menu')
-    handle = feedback.menu_entry_id
-    # Update
-    if handle == 1:
-        for sensor in sensors:
-            for joint in xml_robot.joints:  # find corresponding joint for this sensor
+        # Load the urdf from /robot_description
+        self.urdf = URDF.from_parameter_server()
+
+        ok = validateLinks(self.config.world_link, self.config.sensors, self.urdf)
+        if not ok: sys.exit(1)
+
+        print('Number of sensors: ' + str(len(self.config.sensors)))
+
+        # Init interaction
+        self.server = InteractiveMarkerServer("interactive_first_guess")
+        self.menu   = MenuHandler()
+
+        self.menu.insert("Save sensors configuration",     callback=self.onSaveFirstGuess)
+        self.menu.insert("Reset to initial configuration", callback=self.onReset)
+
+        # For each node generate an interactive marker.
+        for name, sensor in self.config.sensors.items():
+            print(Fore.BLUE + '\nSensor name is ' + name + Style.RESET_ALL)
+            params = {
+                "frame_world":      self.config.world_link,
+                "frame_opt_parent": sensor.parent_link,
+                "frame_opt_child":  sensor.child_link,
+                "frame_sensor":     sensor.link,
+                "marker_scale":     self.args['marker_scale']}
+            # Append to the list of sensors
+            self.sensors.append(Sensor(sensor.name, self.server, self.menu, **params))
+
+        self.server.applyChanges()
+
+    def onSaveFirstGuess(self, feedback):
+        for sensor in self.sensors:
+            for joint in self.urdf.joints:  # find corresponding joint for this sensor
                 if sensor.opt_child_link == joint.child and sensor.opt_parent_link == joint.parent:
                     trans = sensor.optT.getTranslation()
                     euler = sensor.optT.getEulerAngles()
-                    joint.origin.xyz[0] = trans[0]
-                    joint.origin.xyz[1] = trans[1]
-                    joint.origin.xyz[2] = trans[2]
-                    joint.origin.rpy[0] = euler[0]
-                    joint.origin.rpy[1] = euler[1]
-                    joint.origin.rpy[2] = euler[2]
+                    joint.origin.xyz = list(trans)
+                    joint.origin.rpy = list(euler)
 
-        xml_string = xml_robot.to_xml_string()
-        filename = rospack.get_path('interactive_calibration') + args['filename']
-        f = open(filename, "w")
-        f.write(xml_string)
-        f.close()
-        print('Saved first guess to file ' + filename)
-    if handle == 2:
-        for sensor in sensors:
-            interactive_calibration.sensor.Sensor.resetToInitalPose(sensor)
+        # Write the urdf file with interactive_calibration's source path as base directory.
+        rospack = rospkg.RosPack()
+        outfile = rospack.get_path('interactive_calibration') + os.path.abspath('/' + self.args['filename'])
+        with open(outfile, 'w') as out:
+            print("Writing fist guess urdf to '{}'".format(outfile))
+            out.write(self.urdf.to_xml_string())
 
-
-def initMenu():
-    menu_handler.insert("Save sensors configuration", callback=menuFeedback)
-    menu_handler.insert("Reset to initial configuration", callback=menuFeedback)
+    def onReset(self, feedback):
+        for sensor in self.sensors:
+            sensor.resetToInitalPose()
 
 
 if __name__ == "__main__":
 
     # Parse command line arguments
     ap = argparse.ArgumentParser()
-    ap.add_argument("-w", "--world_link", help='Name of the reference frame wich is common to all sensors. Usually '
-                                               'it is the world or base_link.', type=str, required=True)
-    ap.add_argument("-f", "--filename", help="Path to the file where it will be the first guess file, starting from the root of the interactive calibration ros package",
-                    type=str, required=True, default="/calibrations/atlascar2/atlascar2_first_guess.urdf.xacro")
-    ap.add_argument("-s", "--marker_scale", help='Scale of the interactive markers.', type=float, default=0.6)
-    ap.add_argument("-c", "--calibration_file", help='full path to calibration file.', type=str, required=True)
+    ap.add_argument("-f", "--filename", type=str, required=True, default="/calibrations/atlascar2/atlascar2_first_guess.urdf.xacro",
+                    help="Full path and name of the first guess xacro file. Starting from the root of the interactive calibration ros package")
+    ap.add_argument("-s", "--marker_scale",     type=float, default=0.6, help='Scale of the interactive markers.')
+    ap.add_argument("-c", "--calibration_file", type=str, required=True, help='full path to calibration file.')
+
     args = vars(ap.parse_args())
 
     # Initialize ROS stuff
     rospy.init_node("sensors_first_guess")
-    rospack = rospkg.RosPack()  # get an instance of RosPack with the default search paths
-    server = InteractiveMarkerServer("sensors_first_guess")
-    robot_description = rospy.get_param('/robot_description')
-    rospy.sleep(0.5)
 
-    # Parse robot description from param /robot_description
-    xml_robot = URDF.from_parameter_server()
-    robot_from_json = json.load(open(args['calibration_file'], 'r'))
+    # Launch the application !!
+    first_guess = InteractiveFirstGuess(args)
+    first_guess.init()
 
-    # Process robot description and create an instance of class Sensor for each sensor
-    number_of_sensors = 0
-    sensors = []
-
-    print('Number of sensors: ' + str(len(robot_from_json)))
-
-    # parsing of robot description
-    # for i, xml_sensor in enumerate(xml_robot.sensors):
-    for key, value in robot_from_json.items():
-
-        print(Fore.BLUE + '\n\nSensor name is ' + key + Style.RESET_ALL)
-
-        #TODO put this in a function and adapt for the json case
-        # # Check if we have all the information needed. Abort if not.
-        # for attr in ['parent', 'calibration_parent', 'calibration_child']:
-        #     if not hasattr(xml_sensor, attr):
-        #         raise ValueError(
-        #             'Element ' + attr + ' for sensor ' + xml_sensor.name + ' must be specified in the urdf/xacro.')
-
-        # Append to the list of sensors
-        sensors.append(interactive_calibration.sensor.Sensor(key, server, menu_handler, args['world_link'],
-                                                             value['calibration_parent_link'],
-                                                             value['calibration_child_link'], value['sensor_link'],
-                                                             marker_scale=args['marker_scale']))
-
-    initMenu()
-    server.applyChanges()
     print('Changes applied ...')
 
     rospy.spin()
+


### PR DESCRIPTION
Here is my proposal for the *calibration configuration*. The calibration file is structured as discussed in our meeting.

Right now, the new calib config, is implemented in the `create_first_guess.py`. I also validate the config JSON and the sensors link chains. The `collect_and_label_data.py` still works with the "old" version of the configuration file. It serves as a comparison.

I did the tests and it works with Atlas dataset. The *urdf* file is saved with the correct *first guess* transformations. 

I also toke the liberty to refactor the `create_first_guess.py`.